### PR TITLE
Fix sidepost validation silently failing

### DIFF
--- a/lib/jsonapi_compliable/util/validation_response.rb
+++ b/lib/jsonapi_compliable/util/validation_response.rb
@@ -45,26 +45,28 @@ class JsonapiCompliable::Util::ValidationResponse
   end
 
   def all_valid?(model, deserialized_params)
-    valid = true
-    return false unless valid_object?(model)
+    checks = []
+    checks << valid_object?(model)
     deserialized_params.each_pair do |name, payload|
       if payload.is_a?(Array)
         related_objects = model.send(name)
-        related_objects.each do |r|
+        related_objects.each_with_index do |r, index|
           valid = valid_object?(r)
+          checks << valid
 
           if valid
-            valid = all_valid?(r, deserialized_params[:relationships] || {})
+            checks << all_valid?(r, payload[index][:relationships] || {})
           end
         end
       else
         related_object = model.send(name)
         valid = valid_object?(related_object)
+        checks << valid
         if valid
-          valid = all_valid?(related_object, deserialized_params[:relationships] || {})
+          checks << all_valid?(related_object, payload[:relationships] || {})
         end
       end
     end
-    valid
+    checks.all? { |c| c == true }
   end
 end


### PR DESCRIPTION
Sidepost Child A and Child B on Parent, (method: ‘update’)

If Child A is invalid and Child B is valid I get 200 and the fully patched response for all models, although Child A will not in fact be persisted.

If I remove Child B (the valid one) and sidepost again I get the expected 422 and an errors hash.

This fix is copied from https://github.com/graphiti-api/graphiti/issues/38